### PR TITLE
Explicit :aot class as required by lein 3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main exopaste.main
+  :aot [exopaste.main]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [aleph "0.4.6"]

--- a/src/exopaste/main.clj
+++ b/src/exopaste/main.clj
@@ -1,5 +1,6 @@
 (ns exopaste.main
-  (:require [exopaste.system :refer [init-system start!]]))
+  (:require [exopaste.system :refer [init-system start!]])
+  (:gen-class))
 
 (defn -main [& args]
   (init-system)


### PR DESCRIPTION
The sample code fails to compile/run with leiningen 2.9.3, producing an error on `lein uberjar`:

```
Warning: specified :main without including it in :aot
Implicit AOT of :main will be removed in leiningen 3.0.0.
If you only need AOT for your uberjar, consider adding :aot :all into your
:uberjar profile instead.
Compiling exopaste.main
Warning: The Main-Class specified does not exist within the jar. It may not be executable as expected. A gen-class directive may be missing in the namespace which contains the main method, or the namespace has not been AOT-compiled
```

And it produces the following error on `java -jar target/exopaste-0.1.0-SNAPSHOT-standalone.jar`:

```
Error: Could not find or load main class exopaste.main
Caused by: java.lang.ClassNotFoundException: exopaste.main
```

This pull request fixes this error, and allows `lein uberjar` to produce a runnable .jar file with leiningen 2.9.3.
